### PR TITLE
modernized pivot motor implementation

### DIFF
--- a/src/main/cpp/CowLib/CowMotor/PhoenixV5TalonFX.cpp
+++ b/src/main/cpp/CowLib/CowMotor/PhoenixV5TalonFX.cpp
@@ -215,16 +215,16 @@ namespace CowMotor
 
     void PhoenixV5TalonFX::SetPID(double p, double i, double d, double f)
     {
-        m_Talon->Config_kP(0, p, 100);
-        m_Talon->Config_kI(0, i, 100);
-        m_Talon->Config_kD(0, d, 100);
-        m_Talon->Config_kF(0, f, 100);
+        m_Talon->Config_kP(0, p, 0);
+        m_Talon->Config_kI(0, i, 0);
+        m_Talon->Config_kD(0, d, 0);
+        m_Talon->Config_kF(0, f, 0);
     }
 
     void PhoenixV5TalonFX::SetMotionMagic(double velocity, double acceleration)
     {
-        m_Talon->ConfigMotionAcceleration(acceleration,100);
-        m_Talon->ConfigMotionCruiseVelocity(velocity,100);
+        m_Talon->ConfigMotionAcceleration(acceleration,0);
+        m_Talon->ConfigMotionCruiseVelocity(velocity,0);
     }
 
     void PhoenixV5TalonFX::SetInverted(bool inverted)

--- a/src/main/cpp/Subsystems/Pivot/Pivot.h
+++ b/src/main/cpp/Subsystems/Pivot/Pivot.h
@@ -9,6 +9,8 @@
 
 #include "../../CowConstants.h"
 #include "../../CowLib/Conversions.h"
+#include "../../CowLib/CowMotorController.h"
+#include "../../CowLib/CowMotor/CowMotorUtils.h"
 #include "PivotInterface.h"
 
 #include <ctre/Phoenix.h>
@@ -46,7 +48,9 @@ public:
     void Handle();
 
 private:
-    std::shared_ptr<ctre::phoenix::motorcontrol::can::TalonFX> m_PivotMotor;
+    CowLib::CowMotorController *m_PivotMotor;
+    CowMotor::MotionMagicPercentOutput m_MotorRequest = { 0 };
+
     double m_TargetAngle;
     int m_TickCount;
 };


### PR DESCRIPTION
also removed timeout from PID config in Phoenix V5 as we weren't checking result anyways